### PR TITLE
Table width adapts to terminal width

### DIFF
--- a/habito/habito.py
+++ b/habito/habito.py
@@ -109,8 +109,11 @@ def list():
     max_col_width = max_col_width if max_col_width > 0 else 20
 
     for r in table_rows:
-        r[0] = '\n'.join(wrap(r[0], max_col_width))
-
+        try:
+            r[0] = '\n'.join(wrap(r[0], max_col_width))
+        except ValueError:
+            click.echo("Please make your terminal window wider and try again")
+            raise SystemExit(1)
     click.echo(table.table)
 
 

--- a/habito/habito.py
+++ b/habito/habito.py
@@ -76,7 +76,7 @@ def list():
     from textwrap import wrap
 
     nr_of_dates = TERMINAL_WIDTH//10 - 2
-    if not nr_of_dates:
+    if nr_of_dates < 1:
         click.echo("Your terminal window is too small. Please make it wider and try again")
         raise SystemExit(1)
 

--- a/habito/habito.py
+++ b/habito/habito.py
@@ -10,7 +10,7 @@ from peewee import *    # noqa
 
 database_name = path.join(click.get_app_dir("habito"), "habito.db")
 db = SqliteDatabase(None)
-
+TERMINAL_WIDTH, TERMINAL_HEIGHT = click.get_terminal_size()
 
 class BaseModel(Model):
 
@@ -75,15 +75,20 @@ def list():
     from terminaltables import SingleTable
     from textwrap import wrap
 
+    nr_of_dates = TERMINAL_WIDTH//10 - 2
+    if not nr_of_dates:
+        click.echo("Your terminal window is too small. Please make it wider and try again")
+        raise SystemExit(1)
+
     table_title = ["Habit", "Goal"]
-    for d in range(0, 10):
+    for d in range(0, nr_of_dates): 
         date_mod = datetime.today() - timedelta(days=d)
         table_title.append("{0}/{1}".format(date_mod.month, date_mod.day))
 
     table_rows = [table_title]
     for habit in HabitModel.select():
         habit_row = [habit.name, str(habit.quantum)]
-        for d in range(0, 10):
+        for d in range(0, nr_of_dates): 
             quanta = 0.0
             column_text = u'\u2717'
             date_mod = datetime.today() - timedelta(days=d)
@@ -109,11 +114,8 @@ def list():
     max_col_width = max_col_width if max_col_width > 0 else 20
 
     for r in table_rows:
-        try:
-            r[0] = '\n'.join(wrap(r[0], max_col_width))
-        except ValueError:
-            click.echo("Please make your terminal window wider and try again")
-            raise SystemExit(1)
+        r[0] = '\n'.join(wrap(r[0], max_col_width))
+
     click.echo(table.table)
 
 

--- a/tests/test_habito.py
+++ b/tests/test_habito.py
@@ -53,7 +53,7 @@ class HabitoTests(TestCase):
             else:
                 expect(result.exit_code).to.be(0)
                 for i in range(0, nr_of_dates + 1):
-                    date_string = (datetime.now() + timedelta(days=i)).strftime("%-m/%-d")
+                    date_string = "{dt.month}/{dt.day}".format(dt=(datetime.now() + timedelta(days=i)))
                     expect(result.output).to.contain(date_string)
 
     def test_habito_list_lists_tracked_habits(self):

--- a/tests/test_habito.py
+++ b/tests/test_habito.py
@@ -42,7 +42,7 @@ class HabitoTests(TestCase):
         # result = habito.cli()
         pass
     
-    def test_habito_list_gives_warning_if_terminal_too_small(self):
+    def test_habito_list_table_adapts_to_terminal_width(self):
         for terminal_width in range(0, 101, 5):
             nr_of_dates = terminal_width//10 - 2
             habito.TERMINAL_WIDTH = terminal_width 


### PR DESCRIPTION
The width of the table will change depending on the terminal width. If the terminal is too small to output at least one date column, a warning will be echoed.

All tests passing.