### PR TITLE
Edit and delete commands added

### DIFF
--- a/habito/habito.py
+++ b/habito/habito.py
@@ -87,7 +87,7 @@ def list():
 
     table_rows = [table_title]
     for habit in HabitModel.select():
-        habit_row = [habit.name, str(habit.quantum)]
+        habit_row = [str(habit.id) + ": " + habit.name, str(habit.quantum)]
         for d in range(0, nr_of_dates): 
             quanta = 0.0
             column_text = u'\u2717'
@@ -139,6 +139,37 @@ def add(name, quantum, units):
     HabitModel.create(name=habit_name,
                       created_date=datetime.now(), quantum=quantum,
                       units=units, magica="")
+
+@cli.command()
+@click.argument("id", type=click.INT)
+@click.option('--name', '-n', help="The new name (leave empty to leave unchanged)")
+@click.option('--quantum', '-q', help="The new quantum (leave empty to leave unchanged)", type=click.FLOAT)
+def edit(id, name, quantum):
+    try:
+        habit = HabitModel.get(HabitModel.id == id)
+    except DoesNotExist:
+        click.echo("The habit you're trying to edit does not exist!")
+        raise SystemExit(1)
+    habit.name = name.strip() or habit.name
+    habit.quantum = quantum or habit.quantum
+    habit.save()
+    click.echo("Habit with id {} has been saved with name: {} and quantum: {}".format(id, habit.name, habit.quantum))
+
+
+@cli.command()
+@click.argument("id", type=click.INT)
+def delete(id):
+    try:
+        habit = HabitModel.get(HabitModel.id == id)
+    except DoesNotExist:
+        click.echo("The habit you want to remove does not seem to exist!")
+        raise SystemExit(1)
+    confirm = click.prompt("Are you sure you want to delete habit {}: {} (this cannot be undone!)".format(habit.id, habit.name))
+    if confirm:
+        click.echo("Habit {}: {} has been deleted!".format(habit.id, habit.name))
+        habit.delete_instance()
+    else:
+        click.echo("Habit {}: {} has not been deleted!".format(habit.id, habit.name))
 
 
 @cli.command()

--- a/habito/habito.py
+++ b/habito/habito.py
@@ -158,7 +158,8 @@ def edit(id, name, quantum):
 
 @cli.command()
 @click.argument("id", type=click.INT)
-def delete(id):
+@click.option("--keeplogs", is_flag=True, default=False)
+def delete(id, keeplogs):
     try:
         habit = HabitModel.get(HabitModel.id == id)
     except DoesNotExist:
@@ -167,6 +168,9 @@ def delete(id):
     confirm = click.prompt("Are you sure you want to delete habit {}: {} (this cannot be undone!)".format(habit.id, habit.name))
     if confirm:
         click.echo("Habit {}: {} has been deleted!".format(habit.id, habit.name))
+        if not keeplogs:
+            ad = ActivityModel.delete().where(ActivityModel.for_habit == habit.id)
+            ad.execute()
         habit.delete_instance()
     else:
         click.echo("Habit {}: {} has not been deleted!".format(habit.id, habit.name))

--- a/tests/test_habito.py
+++ b/tests/test_habito.py
@@ -151,14 +151,25 @@ class HabitoTests(TestCase):
 
     def test_delete(self):
         self._create_habit_one()
+        self._run_command(habito.checkin, ["HabitModel", "-q 3"])
+        expect(habito.ActivityModel.select().count()).to.equal(1)
         delete_result = self._run_command_with_stdin(habito.delete, ["1"], "y")
         expect("Are you sure you want to delete habit 1: HabitModel One (this cannot be undone!)").to.be.within(delete_result.output)
         expect("Habit 1: HabitModel One has been deleted!").to.be.within(delete_result.output)
+        expect(habito.HabitModel.select().count()).to.equal(0)
         expect(habito.HabitModel.select().count()).to.equal(0)
 
     def test_non_existing_delete(self):
         delete_result = self._run_command(habito.delete, ["20"])
         expect("The habit you want to remove does not seem to exist!").to.be.within(delete_result.output)
+
+    def test_delete_with_keep_logs(self):
+        self._create_habit_one()
+        self._run_command(habito.checkin, ["HabitModel", "-q 3"])
+        expect(habito.ActivityModel.select().count()).to.equal(1)
+        delete_result = self._run_command_with_stdin(habito.delete, ["1", "--keeplogs"], "y")
+        expect(habito.ActivityModel.select().count()).to.equal(1)
+
     def _run_command(self, command, args=[]):
         return self._run_command_with_stdin(command, args, stdin=None)
 


### PR DESCRIPTION
This makes it possible to edit and delete habits.

Simple example:
![schermafbeelding 2016-05-19 om 23 11 49](https://cloud.githubusercontent.com/assets/419844/15409891/29d4240c-1e17-11e6-83ec-87ca14df67ba.png)
