### PR TITLE
Pick date

### DIFF
--- a/habito/habito.py
+++ b/habito/habito.py
@@ -140,12 +140,18 @@ def add(name, quantum, units):
                       created_date=datetime.now(), quantum=quantum,
                       units=units, magica="")
 
+def process_date(date_str):
+    human_readable_timedeltas = {"today": 0,
+                                 "yesterday": 1}
+    date_str = date_str.lower()
+    
 
 @cli.command()
 @click.argument("name", nargs=-1)
+@click.option("--date", "-d", help="The date (defaults to today)", default=datetime.now().strftime("%m/%d"))
 @click.option("--quantum", "-q", help="Quanta of data for the day",
               prompt=True)
-def checkin(name, quantum):
+def checkin(name, date, quantum):
     """Commit data for a habit."""
     query = ' '.join(name)
     habits = HabitModel.select().where(HabitModel.name.regexp(query))
@@ -161,6 +167,7 @@ def checkin(name, quantum):
             click.echo(h.name)
         return
 
+    update_date = datetime.strptime(date, "%m/%d")
     habit = habits[0]
     activity = ActivityModel.create(for_habit=habit,
                                     quantum=quantum,

--- a/habito/habito.py
+++ b/habito/habito.py
@@ -180,7 +180,8 @@ def checkin(name, date, quantum):
                 nl=False, fg='green')
     click.echo(" to habit")
     click.secho(habit.name, fg='green')
-
+    click.echo("for date: ", nl=False)
+    click.secho(date, fg='green')
 
 if __name__ == "__main__":
     cli()

--- a/habito/habito.py
+++ b/habito/habito.py
@@ -140,11 +140,13 @@ def add(name, quantum, units):
                       created_date=datetime.now(), quantum=quantum,
                       units=units, magica="")
 
+
 def process_date(date_str):
-    human_readable_timedeltas = {"today": 0,
-                                 "yesterday": 1}
-    date_str = date_str.lower()
-    
+    update_date = datetime.strptime(date_str, "%m/%d").replace(year=datetime.now().year)
+    return (update_date
+            if update_date < datetime.now()
+            else update_date.replace(year=update_date.year -1))
+
 
 @cli.command()
 @click.argument("name", nargs=-1)
@@ -167,11 +169,12 @@ def checkin(name, date, quantum):
             click.echo(h.name)
         return
 
-    update_date = datetime.strptime(date, "%m/%d")
+    update_date = process_date(date)
+    click.echo(update_date)
     habit = habits[0]
     activity = ActivityModel.create(for_habit=habit,
                                     quantum=quantum,
-                                    update_date=datetime.now())
+                                    update_date=update_date)
     click.echo("Added ", nl=False)
     click.secho("{0} {1}".format(activity.quantum, habit.units),
                 nl=False, fg='green')

--- a/tests/test_habito.py
+++ b/tests/test_habito.py
@@ -23,17 +23,16 @@ class HabitoTests(TestCase):
         habito.database_name = ":memory:"
         habito.db.init(habito.database_name)
         habito.db.create_tables([habito.HabitModel, habito.ActivityModel],
-                                safe=True)
+                safe=True)
 
     def tearDown(self):
-        habito.db.drop_tables([habito.HabitModel, habito.ActivityModel],
-                              safe=True)
+        habito.db.drop_tables([habito.HabitModel, habito.ActivityModel], safe=True)
 
     def test_habito_cli_sets_up_default_commandset(self):
         result = habito.cli
 
         commands = { 'list': habito.list, 'add': habito.add,
-                    'checkin': habito.checkin }
+            'checkin': habito.checkin }
 
         expect(result.commands).to.equal(commands)
 
@@ -41,7 +40,7 @@ class HabitoTests(TestCase):
         # See https://github.com/mitsuhiko/click/issues/344
         # result = habito.cli()
         pass
-    
+
     def test_habito_list_table_adapts_to_terminal_width(self):
         for terminal_width in range(0, 101, 5):
             nr_of_dates = terminal_width//10 - 2
@@ -67,14 +66,14 @@ class HabitoTests(TestCase):
 
     def test_habito_add_should_add_a_habit(self):
         result = self._run_command(habito.add,
-                                   ["dummy habit", "10.01"])
+                ["dummy habit", "10.01"])
 
         expect(habito.HabitModel.select().count()).to.be(1)
         expect(habito.HabitModel.select()[0].name).to.eql("dummy habit")
 
     def test_habito_checkin_should_show_error_if_no_habit_exists(self):
         result = self._run_command(habito.checkin,
-                                   ["dummy habit", "-q 9.1"])
+                ["dummy habit", "-q 9.1"])
 
         expect(result.exit_code).to.be(0)
         expect(result.output.startswith("No tracked habits match the")).to.true
@@ -83,12 +82,12 @@ class HabitoTests(TestCase):
         dummy_date = date(1201, 10, 12)
         habit = self._create_habit_one()
         habit_two = self._create_habit(name="HabitModel Two",
-                                       created_date=dummy_date,
-                                       quantum=0,
-                                       magica="be awesome!")
+                created_date=dummy_date,
+                quantum=0,
+                magica="be awesome!")
 
         result = self._run_command(habito.checkin,
-                                   ["HabitModel", "-q 9.1"])
+                ["HabitModel", "-q 9.1"])
 
         expect(result.exit_code).to.be(0)
         expect(result.output.startswith("More than one tracked habits match the")).to.true
@@ -98,10 +97,10 @@ class HabitoTests(TestCase):
         result_units = "9.1 dummy_units"
 
         result = self._run_command(habito.checkin,
-                                   ["HabitModel", "-q 9.1"])
+                ["HabitModel", "-q 9.1"])
 
         activity_entry = habito.ActivityModel\
-            .get(habito.ActivityModel.for_habit == habit)
+                .get(habito.ActivityModel.for_habit == habit)
 
         expect(result.output.find(result_units)).to.not_be(-1)
         expect(result.output.find(habit.name)).to.not_be(-1)
@@ -116,7 +115,7 @@ class HabitoTests(TestCase):
         result = self._run_command(habito.checkin, ["HabitModel", "-q 10.0001"])
 
         activity_entry = habito.ActivityModel\
-            .select().where(habito.ActivityModel.for_habit == habit)
+                .select().where(habito.ActivityModel.for_habit == habit)
 
         expect(result.output.find(result_units_two)).to.not_be(-1)
         expect(result.output.find(habit.name)).to.not_be(-1)
@@ -132,6 +131,11 @@ class HabitoTests(TestCase):
 
         expect(result.exit_code).to.be(0)
         expect(result.output.find(result_units_one)).to.not_be(-1)
+    
+    def test_process_date(self):
+        current_year = datetime.now().year
+        expect(habito.process_date("5/17").date()).to.equal(date(current_year, 5, 17))
+        expect(habito.process_date("12/31").date()).to.equal(date(current_year-1, 12, 31))
 
 
     def _run_command(self, command, args=[]):
@@ -147,7 +151,7 @@ class HabitoTests(TestCase):
 
     def _create_habit(self, name, created_date, quantum, magica):
         habit = habito.HabitModel.create(name=name,
-                                         created_date=created_date,
+                created_date=created_date,
                                          quantum=quantum,
                                          units="dummy_units",
                                          magica=magica)

--- a/tests/test_habito.py
+++ b/tests/test_habito.py
@@ -138,6 +138,16 @@ class HabitoTests(TestCase):
         expect(habito.process_date("12/31").date()).to.equal(date(current_year-1, 12, 31))
 
 
+    def test_custom_date_checkin(self):
+        self._create_habit_one()
+        today = datetime.now()
+        for i in range(5):
+            d = today - timedelta(days=i)
+            date_str = "{d.month}/{d.day}".format(d=d)
+            self._run_command(habito.checkin, ["HabitModel", "-d {}".format(date_str), "-q 35.0"])
+        list_result = self._run_command(habito.list)
+        expect(list_result.output.count("35")).to.equal(5)
+
     def _run_command(self, command, args=[]):
         return self._run_command_with_stdin(command, args, stdin=None)
 

--- a/tests/test_habito.py
+++ b/tests/test_habito.py
@@ -144,7 +144,9 @@ class HabitoTests(TestCase):
         for i in range(5):
             d = today - timedelta(days=i)
             date_str = "{d.month}/{d.day}".format(d=d)
-            self._run_command(habito.checkin, ["HabitModel", "-d {}".format(date_str), "-q 35.0"])
+            checkin_result = self._run_command(habito.checkin, ["HabitModel", "-d {}".format(date_str), "-q 35.0"])
+            expect(checkin_result.output).to.be.within("for date: {}".format(date_str))
+            expect(checkin_result.output).to.be.within("35.0 units")
         list_result = self._run_command(habito.list)
         expect(list_result.output.count("35")).to.equal(5)
 


### PR DESCRIPTION
This allows you to pick a date for a checkin. This is useful if you forgot to log an activity.

Note: one of the tests fails, even though the code works. I don't know what's wrong with it; maybe I'm just tired. :) It keeps complaining that the input date doesn't match '%m/%d', but it does... Very weird, maybe I'm missing something obvious somewhere. Feel free to take a look at it.
